### PR TITLE
fix:解决MODEL_DENSE引用处未修改，设置MODEL_DENSE后训练报错的问题

### DIFF
--- a/stagesepx/classifier/keras.py
+++ b/stagesepx/classifier/keras.py
@@ -151,8 +151,8 @@ class KerasClassifier(BaseModelClassifier):
             ), f"dataset only contains one class. maybe some path errors happened: {p}?"
 
             # more than 6 classes?
-            assert number_of_dir <= 6, (
-                f"dataset has {number_of_dir} classes (more than 6), please see "
+            assert number_of_dir <= self.MODEL_DENSE, (
+                f"dataset has {number_of_dir} classes (more than " + str(self.MODEL_DENSE) + "), please see "
                 f"https://github.com/williamfzc/stagesepx/issues/112 "
             )
 


### PR DESCRIPTION
MODEL_DENSE允许设置修改后，但是train中的方法依旧是固定的6，所以做了一个调整